### PR TITLE
Improve responsive layout across pages

### DIFF
--- a/app/_components/Cabin.tsx
+++ b/app/_components/Cabin.tsx
@@ -7,18 +7,13 @@ import { CabinsDataType } from "@/@types/next-auth";
 function Cabin({ cabin }: { cabin: CabinsDataType }) {
   const { name, maxCapacity, image, description } = cabin;
   return (
-    <div className="border-primary-800 mb-24 grid grid-cols-[3fr_4fr] gap-20 border px-10 py-3">
-      <div className="relative -translate-x-3">
-        <Image
-          src={image}
-          fill
-          className="object-cover"
-          alt={`Cabin ${name}`}
-        />
+    <div className="border-primary-800 mb-24 grid gap-10 border px-4 py-3 md:grid-cols-[3fr_4fr] md:gap-20 md:px-10">
+      <div className="relative md:-translate-x-3">
+        <Image src={image} fill className="object-cover" alt={`Cabin ${name}`} />
       </div>
 
       <div>
-        <h3 className="text-accent-100 bg-primary-950 mb-5 w-[150%] translate-x-[-254px] p-6 pb-1 text-7xl font-black">
+        <h3 className="text-accent-100 bg-primary-950 mb-5 text-4xl font-black md:w-[150%] md:-translate-x-[254px] md:p-6 md:pb-1 md:text-7xl">
           Cabin {name}
         </h3>
 
@@ -34,8 +29,7 @@ function Cabin({ cabin }: { cabin: CabinsDataType }) {
           <li className="flex items-center gap-3">
             <MapPinIcon className="text-primary-600 h-5 w-5" />
             <span className="text-lg">
-              Located in the heart of the{" "}
-              <span className="font-bold">Dolomites</span> (Italy)
+              Located in the heart of the <span className="font-bold">Dolomites</span> (Italy)
             </span>
           </li>
           <li className="flex items-center gap-3">

--- a/app/_components/CabinCard.tsx
+++ b/app/_components/CabinCard.tsx
@@ -3,26 +3,23 @@ import { UsersIcon } from "@heroicons/react/24/solid";
 import Image from "next/image";
 import Link from "next/link";
 
-
 function CabinCard({ cabin }: { cabin: CabinsDataType }) {
   const { id, name, maxCapacity, regularPrice, discount, image } = cabin;
 
   return (
-    <div className="border-primary-800 flex border">
-      <div className="relative flex-1">
+    <div className="border-primary-800 flex flex-col border sm:flex-row">
+      <div className="relative h-52 flex-shrink-0 sm:h-auto sm:flex-1">
         <Image
           src={image}
           fill
           alt={`Cabin ${name}`}
-          className="border-primary-800 border-r object-cover"
+          className="border-primary-800 object-cover sm:border-r"
         />
       </div>
 
       <div className="flex-grow">
         <div className="bg-primary-950 px-7 pt-5 pb-4">
-          <h3 className="text-accent-500 mb-3 text-2xl font-semibold">
-            Cabin {name}
-          </h3>
+          <h3 className="text-accent-500 mb-3 text-2xl font-semibold">Cabin {name}</h3>
 
           <div className="mb-2 flex items-center gap-3">
             <UsersIcon className="text-primary-600 h-5 w-5" />
@@ -34,12 +31,8 @@ function CabinCard({ cabin }: { cabin: CabinsDataType }) {
           <p className="flex items-baseline justify-end gap-3">
             {discount > 0 ? (
               <>
-                <span className="text-3xl font-[350]">
-                  ${regularPrice - discount}
-                </span>
-                <span className="text-primary-600 font-semibold line-through">
-                  ${regularPrice}
-                </span>
+                <span className="text-3xl font-[350]">${regularPrice - discount}</span>
+                <span className="text-primary-600 font-semibold line-through">${regularPrice}</span>
               </>
             ) : (
               <span className="text-3xl font-[350]">${regularPrice}</span>

--- a/app/_components/DateSelector.tsx
+++ b/app/_components/DateSelector.tsx
@@ -42,7 +42,7 @@ function DateSelector({ settings, cabin, bookedDates }: DateSelectorProps) {
   const { minBookingLength, maxBookingLength } = settings;
 
   return (
-    <div className="flex max-w-[600px] flex-col justify-between overflow-x-auto">
+    <div className="flex max-w-full flex-col justify-between overflow-x-auto md:max-w-[600px]">
       <DayPicker
         style={{ transform: "scale(0.8)", transformOrigin: "center" }}
         classNames={{

--- a/app/_components/Header.tsx
+++ b/app/_components/Header.tsx
@@ -3,8 +3,8 @@ import Logo from '@/app/_components/Logo';
 
 function Header() {
   return (
-    <header className='border-b border-primary-900 px-8 py-5'>
-      <div className='flex justify-between items-center max-w-7xl mx-auto'>
+    <header className="border-b border-primary-900 px-4 py-5 md:px-8">
+      <div className="mx-auto flex items-center justify-between max-w-7xl">
         <Logo />
         <Navigation />
       </div>

--- a/app/_components/Navigation.tsx
+++ b/app/_components/Navigation.tsx
@@ -1,59 +1,7 @@
-import Link from "next/link";
-import React from "react";
-import Image from "next/image";
 import { auth } from "../_lib/auth";
+import NavigationClient from "./NavigationClient";
 
-async function Navigation() {
+export default async function Navigation() {
   const session = await auth();
-
-  return (
-    <nav className="z-10 text-xl">
-      <ul className="flex items-center gap-16">
-        <li>
-          <Link
-            href="/cabins"
-            className="hover:text-accent-400 transition-colors"
-          >
-            Cabins
-          </Link>
-        </li>
-        <li>
-          <Link
-            href="/about"
-            className="hover:text-accent-400 transition-colors"
-          >
-            About
-          </Link>
-        </li>
-        <li>
-          {session?.user?.image ? (
-            <Link
-              href="/account"
-              className="hover:text-accent-400 flex items-center gap-4 transition-colors"
-            >
-              <div className="relative h-8 w-8">
-                <Image
-                  src={session.user.image}
-                  fill
-                  className="h-8 rounded-full object-cover"
-                  alt="avatar image"
-                  referrerPolicy="no-referrer"
-                />
-              </div>
-              <span>Guest area</span>
-            </Link>
-          ) : (
-            <Link
-              href="/account"
-              className="hover:text-accent-400 transition-colors"
-            >
-              Guest area
-            </Link>
-          )}
-        </li>
-      </ul>
-    </nav>
-  );
+  return <NavigationClient session={session} />;
 }
-
-export default Navigation;

--- a/app/_components/NavigationClient.tsx
+++ b/app/_components/NavigationClient.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/solid'
+import Link from 'next/link'
+import Image from 'next/image'
+import { Session } from 'next-auth'
+import { useState } from 'react'
+
+interface Props {
+  session: Session | null
+}
+
+export default function NavigationClient({ session }: Props) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div className="relative">
+      <button
+        className="text-primary-100 md:hidden"
+        onClick={() => setOpen((o) => !o)}
+        aria-label="Toggle menu"
+      >
+        {open ? (
+          <XMarkIcon className="h-8 w-8" />
+        ) : (
+          <Bars3Icon className="h-8 w-8" />
+        )}
+      </button>
+      <nav
+        className={`${
+          open ? 'block' : 'hidden'
+        } absolute right-0 top-full mt-2 w-40 rounded-md border border-primary-800 bg-primary-950 p-4 md:static md:block md:w-auto md:border-0 md:p-0`}
+      >
+        <ul className="flex flex-col gap-4 md:flex-row md:items-center md:gap-10 text-xl">
+          <li>
+            <Link href="/cabins" className="hover:text-accent-400 transition-colors">
+              Cabins
+            </Link>
+          </li>
+          <li>
+            <Link href="/about" className="hover:text-accent-400 transition-colors">
+              About
+            </Link>
+          </li>
+          <li>
+            {session?.user?.image ? (
+              <Link href="/account" className="hover:text-accent-400 flex items-center gap-3 transition-colors">
+                <div className="relative h-8 w-8">
+                  <Image src={session.user.image} fill className="rounded-full object-cover" alt="avatar image" referrerPolicy="no-referrer" />
+                </div>
+                <span>Guest area</span>
+              </Link>
+            ) : (
+              <Link href="/account" className="hover:text-accent-400 transition-colors">
+                Guest area
+              </Link>
+            )}
+          </li>
+        </ul>
+      </nav>
+    </div>
+  )
+}

--- a/app/_components/Reservation.tsx
+++ b/app/_components/Reservation.tsx
@@ -19,7 +19,7 @@ async function Reservation({ cabin }: ReservationProps) {
   const session = await auth();
 
   return (
-    <div className="border-primary-800 grid min-h-[400px] grid-cols-2 border">
+    <div className="border-primary-800 grid min-h-[400px] grid-cols-1 border md:grid-cols-2">
       <DateSelector
         settings={settings}
         bookedDates={bookedDates}

--- a/app/_components/ReservationForm.tsx
+++ b/app/_components/ReservationForm.tsx
@@ -32,7 +32,7 @@ function ReservationForm({ cabin, user }: ReservationFormProps) {
 
   return (
     <div>
-      <div className="bg-primary-800 text-primary-300 flex items-center justify-between px-16 py-2">
+      <div className="bg-primary-800 text-primary-300 flex items-center justify-between px-6 py-2 md:px-16">
         <p>Logged in as</p>
 
         <div className="flex items-center gap-4">
@@ -54,7 +54,7 @@ function ReservationForm({ cabin, user }: ReservationFormProps) {
           createBookingWithData(formData);
           resetRange();
         }}
-        className="bg-primary-900 flex flex-col gap-5 px-16 py-10 text-lg"
+        className="bg-primary-900 flex flex-col gap-5 px-6 py-8 text-lg md:px-16 md:py-10"
       >
         <div className="space-y-2">
           <label htmlFor="numGuests">How many guests?</label>

--- a/app/_components/SideNavigation.tsx
+++ b/app/_components/SideNavigation.tsx
@@ -30,8 +30,8 @@ const navLinks = [
 function SideNavigation() {
   const pathname = usePathname();
   return (
-    <nav className="border-primary-900 border-r">
-      <ul className="flex h-full flex-col gap-2 text-lg">
+    <nav className="border-primary-900 border-b md:border-b-0 md:border-r">
+      <ul className="flex flex-row gap-2 text-lg md:h-full md:flex-col">
         {navLinks.map((link) => (
           <li key={link.name}>
             <Link
@@ -44,7 +44,7 @@ function SideNavigation() {
           </li>
         ))}
 
-        <li className="mt-auto">
+        <li className="md:mt-auto">
           <SignOutButton />
         </li>
       </ul>

--- a/app/account/layout.tsx
+++ b/app/account/layout.tsx
@@ -3,7 +3,7 @@ import SideNavigation from "@/app/_components/SideNavigation";
 
 function Layout({ children }: RootLayoutProps) {
   return (
-    <div className="grid h-full grid-cols-[16rem_1fr] gap-12">
+    <div className="grid h-full gap-12 md:grid-cols-[16rem_1fr]">
       <SideNavigation />
       <div>{children}</div>
     </div>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -26,7 +26,7 @@ export default function RootLayout({ children }: RootLayoutProps) {
         className={`${josefin.className} bg-primary-950 text-primary-100 relative flex min-h-screen flex-col antialiased`}
       >
         <Header />
-        <div className="grid flex-1 px-8 py-12">
+        <div className="grid flex-1 px-4 py-8 md:px-8 md:py-12">
           <main className="mx-auto w-full max-w-7xl">
             <ReservationProvider>{children}</ReservationProvider>
           </main>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,7 @@ import bg from "@/public/bg.png";
 
 export default function Page() {
   return (
-    <main className="mt-24">
+    <main className="mt-24 relative min-h-[60vh]">
       <Image
         src={bg}
         fill
@@ -15,12 +15,12 @@ export default function Page() {
       />
 
       <div className="relative z-10 text-center">
-        <h1 className="text-primary-50 mb-10 text-8xl font-normal tracking-tight">
+        <h1 className="text-primary-50 mb-10 text-5xl font-normal tracking-tight md:text-8xl">
           Welcome to paradise.
         </h1>
         <Link
           href="/cabins"
-          className="bg-accent-500 text-primary-800 hover:bg-accent-600 px-8 py-6 text-lg font-semibold transition-all"
+          className="bg-accent-500 text-primary-800 hover:bg-accent-600 px-6 py-4 text-lg font-semibold transition-all md:px-8 md:py-6"
         >
           Explore luxury cabins
         </Link>


### PR DESCRIPTION
## Summary
- add new `NavigationClient` for mobile menu
- refactor header and navigation usage
- adjust padding and container widths in layout and home page
- tweak cabin and reservation related components for mobile
- update account layout and side navigation

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68469bc2793083269b6aca98a2ed5414